### PR TITLE
resolve import error, libGL.so.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch
-opencv-python
+opencv-python-headless
 numpy
 huggingface_hub
 torchvision


### PR DESCRIPTION
Hello!

When importing your package through ComfyUI-manager, the import doesn't work, and when checking the error log
`ImportError: libGL.so.1: cannot open shared object file: No such file or directory: import cv2:native_module = importlib.import_module("cv2") occurs.`

I've created a PR to solve this! The content is very simple - I've switched cv to a headless package.
Actually, most ComfyUI operating environments are headless environments, so it might even become lighter.
Don't forget that for testing, you must remove the previously installed package
```
pip uninstall opencv-python
```
my testing environment here
```
pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime
COMFYUI_VERSION=v0.3.7
COMFYUI_MANAGER_VERSION=2.55.5
```

I hope you can review it. Thank you!